### PR TITLE
add init container & bump version

### DIFF
--- a/charts/api-server/Chart.yaml
+++ b/charts/api-server/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v2"
 type: "application"
-version: "0.2.1"
+version: "0.2.2"
 appVersion: "0.1.504"
 home: "https://circlesubi.id"
 description: ""

--- a/charts/api-server/templates/deployment.yaml
+++ b/charts/api-server/templates/deployment.yaml
@@ -26,6 +26,12 @@ spec:
       {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      initContainers:
+        - name: {{ .Chart.Name }}-db-migrations
+          image: "{{ .Values.image.repository }}-db-migrations:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          envFrom:
+            - secretRef:
+                name: {{ include "..fullname" . }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:


### PR DESCRIPTION
This brings the new database initialisation container from the `api-server` to its chart.