### PR TITLE
feat(api-server): use canonical migrations image

### DIFF
--- a/charts/api-server/Chart.yaml
+++ b/charts/api-server/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v2"
 type: "application"
-version: "0.2.3"
+version: "0.2.4"
 appVersion: "0.1.504"
 home: "https://circlesubi.id"
 description: ""
@@ -11,4 +11,3 @@ maintainers:
     email: "daniel.janz@gnosis.pm"
   - name: "Jon Richter"
     email: "jon.richter@gnosis.pm"
-

--- a/charts/api-server/templates/deployment.yaml
+++ b/charts/api-server/templates/deployment.yaml
@@ -27,8 +27,8 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       initContainers:
-        - name: {{ .Chart.Name }}-db-migrations
-          image: "{{ .Values.image.repository }}-db-migrations:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        - name: {{ .Chart.Name }}-migrations
+          image: "{{ .Values.image.repository }}-migrations:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           envFrom:
             - secretRef:


### PR DESCRIPTION
This upgrades the `api-server` chart to use the canonical migrations image name, for which we also bump the version to regenerate the Helm package.