### PR TITLE
re-added the config map for the migrations container

### DIFF
--- a/charts/api-server/Chart.yaml
+++ b/charts/api-server/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v2"
 type: "application"
-version: "0.5.0"
+version: "0.5.1"
 appVersion: "0.1.504"
 home: "https://circlesubi.id"
 description: ""

--- a/charts/api-server/templates/deployment.yaml
+++ b/charts/api-server/templates/deployment.yaml
@@ -37,6 +37,8 @@ spec:
           image: "{{ .Values.migrations.image }}:{{ .Values.migrations.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           envFrom:
+            - configMapRef:
+                name: {{ include "..fullname" . }}
             - secretRef:
                 name: {{ include "..fullname" . }}
       containers:


### PR DESCRIPTION
This re-adds the config map to the migrations container, in so the template for the root invitation can be properly converted into SQL.

See OP-165 for details.